### PR TITLE
22 replace all pytesseract with paddle ocr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y insta
 RUN apt-get update && apt-get install -y \
     python3-pip \
     libleptonica-dev \
-    tesseract-ocr \
-    libtesseract-dev \
     python3-pil \
-    tesseract-ocr-eng \
-    tesseract-ocr-script-latn \
     software-properties-common \
     git \
     curl \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 - Python >= 3.8
 - Apex Legends
-- [Tesseract](https://github.com/tesseract-ocr/tesseract/wiki)
 - [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)
 - [PostgreSQL](https://www.postgresql.org/)
 

--- a/apex_ocr/config.py
+++ b/apex_ocr/config.py
@@ -75,10 +75,6 @@ SQUAD_SUMMARY_HEADERS = [
     "Hash",
 ]
 
-# Tesseract configurations
-TESSERACT_CONFIG = "-c tessedit_char_whitelist=()/#01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz --psm 11"
-TESSERACT_BLOCK_CONFIG = "-c tessedit_char_whitelist=()/#01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz --psm 6"
-
 # Regular expressions
 SQUAD_SUMMARY_MAP = {
     "Place": re.compile("#([0-9]{1,2})"),

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -325,7 +325,7 @@ class ApexOCREngine:
             )
 
         # Get text from the images
-        place_text = self.text_from_image_tesseract(squad_place, blur_amount)
+        place_text = self.text_from_image_paddleocr(squad_place, blur_amount)
         total_kills_text = self.text_from_image_tesseract(
             total_kills, blur_amount, TESSERACT_BLOCK_CONFIG
         )

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -223,12 +223,12 @@ class ApexOCREngine:
 
     def text_from_image_paddleocr(self, image: np.ndarray, blur_amount: int) -> str:
         img = self.preprocess_image(image, blur_amount)
-        texts = self.paddle_ocr.ocr(img, det=False, cls=False)[0]
+        texts = self.paddle_ocr.ocr(img, cls=False)[0]
 
         # Concatenate all the recognized strings together
         text = ""
         for t in texts:
-            text += t[0]
+            text += t[1][0]
         text = text.replace("\n", "").replace(" ", "").lower()
 
         return text

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -143,8 +143,12 @@ class ApexOCREngine:
         summary_img = np.array(image.crop(SUMMARY_ROI))
         total_kills_img = np.array(image.crop(TOTAL_KILLS_ROI))
 
-        summary_text = self.text_from_image_paddleocr(summary_img, blur_amount=3)
-        kills_text = self.text_from_image_paddleocr(total_kills_img, blur_amount=3)
+        summary_text = self.text_from_image_paddleocr(
+            summary_img, blur_amount=3, det=True
+        )
+        kills_text = self.text_from_image_paddleocr(
+            total_kills_img, blur_amount=3, det=True
+        )
 
         if debug:
             image.save(
@@ -210,14 +214,19 @@ class ApexOCREngine:
         else:
             self.db_conn = None
 
-    def text_from_image_paddleocr(self, image: np.ndarray, blur_amount: int) -> str:
+    def text_from_image_paddleocr(
+        self, image: np.ndarray, blur_amount: int, det: bool = False
+    ) -> str:
         img = self.preprocess_image(image, blur_amount)
-        texts = self.paddle_ocr.ocr(img, cls=False)[0]
+        texts = self.paddle_ocr.ocr(img, det=det, cls=False)[0]
 
         # Concatenate all the recognized strings together
         text = ""
         for t in texts:
-            text += t[1][0]
+            if det:
+                text += t[1][0]
+            else:
+                text += t[0]
         text = text.replace("\n", "").replace(" ", "").lower()
 
         return text

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import DefaultDict, List, Tuple, Union
 
 import numpy as np
-import pytesseract
 import yaml
 from paddleocr import PaddleOCR
 from PIL import Image, ImageGrab
@@ -98,7 +97,7 @@ class ApexOCREngine:
         # Remove non-numeric and non-slash characters
         text = re.sub("[^0-9/]", "", text)
 
-        # Split text into kills/assitss/knockdowns
+        # Split text into kills/assists/knockdowns
         parts = text.split("/")
 
         if len(parts) == 3:
@@ -176,23 +175,6 @@ class ApexOCREngine:
                 return SummaryType.SQUAD
 
         return None
-
-    @staticmethod
-    def text_from_image_tesseract(
-        image: np.ndarray,
-        blur_amount: int,
-        config: str = TESSERACT_CONFIG,
-        debug: bool = False,
-    ) -> str:
-        img = ApexOCREngine.preprocess_image(image, blur_amount)
-        if debug:
-            Image.fromarray(img).save(
-                DATA_DIRECTORY
-                / f"roi_preprocessed_{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}.png"
-            )
-        text = pytesseract.image_to_string(img, config=config)
-        text = text.replace("\n", "").replace(" ", "").lower()
-        return text
 
     def initialize_database_engine(self):
         if DATABASE:
@@ -302,20 +284,12 @@ class ApexOCREngine:
             logger.error(f"img is None")
             exit(1)
         # Get regions of interest
-        squad_place, total_kills, players = get_rois(img)
+        squad_place, players = get_rois(img)
 
         if debug:
             img.save(
                 DATA_DIRECTORY
                 / f"img_{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}.png"
-            )
-            Image.fromarray(squad_place).save(
-                DATA_DIRECTORY
-                / f"squad_place_{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}.png"
-            )
-            Image.fromarray(total_kills).save(
-                DATA_DIRECTORY
-                / f"total_kills_{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}.png"
             )
             Image.fromarray(squad_place).save(
                 DATA_DIRECTORY

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -143,10 +143,10 @@ class ApexOCREngine:
         total_kills_img = np.array(image.crop(TOTAL_KILLS_ROI))
 
         summary_text = self.text_from_image_paddleocr(
-            summary_img, blur_amount=3, det=True
+            summary_img, blur_amount=3, text_detection=True
         )
         kills_text = self.text_from_image_paddleocr(
-            total_kills_img, blur_amount=3, det=True
+            total_kills_img, blur_amount=3, text_detection=True
         )
 
         if debug:
@@ -197,15 +197,15 @@ class ApexOCREngine:
             self.db_conn = None
 
     def text_from_image_paddleocr(
-        self, image: np.ndarray, blur_amount: int, det: bool = False
+        self, image: np.ndarray, blur_amount: int, text_detection: bool = False
     ) -> str:
         img = self.preprocess_image(image, blur_amount)
-        texts = self.paddle_ocr.ocr(img, det=det, cls=False)[0]
+        texts = self.paddle_ocr.ocr(img, det=text_detection, cls=False)[0]
 
         # Concatenate all the recognized strings together
         text = ""
         for t in texts:
-            if det:
+            if text_detection:
                 text += t[1][0]
             else:
                 text += t[0]

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -324,21 +324,13 @@ class ApexOCREngine:
 
         # Get text from the images
         place_text = self.text_from_image_paddleocr(squad_place, blur_amount)
-        total_kills_text = self.text_from_image_tesseract(
-            total_kills, blur_amount, TESSERACT_BLOCK_CONFIG
-        ) # Want to replace tesseract here but PaddleOCR can't handle squad kills of 1 :(
 
         # Get squad placement
         matches["Place"].extend(
             replace_nondigits(SQUAD_SUMMARY_MAP["Place"].findall(place_text))
         )
 
-        # Get squad kills
-        matches["Squad Kills"].extend(
-            replace_nondigits(
-                SQUAD_SUMMARY_MAP["Squad Kills"].findall(total_kills_text)
-            )
-        )
+        squad_kills = 0
 
         # Get individual player stat
         for player, player_dict in players.items():
@@ -353,6 +345,7 @@ class ApexOCREngine:
             # Get player kills/assists/knockdowns
             kakn_text = self.text_from_image_paddleocr(player_dict["kakn"], blur_amount)
             kills, assists, knocks = self.process_kakn(kakn_text)
+            squad_kills += kills
             matches[player.upper() + " Kills"].append(kills)
             matches[player.upper() + " Assists"].append(assists)
             matches[player.upper() + " Knocks"].append(knocks)
@@ -382,6 +375,9 @@ class ApexOCREngine:
                 blur_amount,
             )
             matches[player.upper() + " Respawns"].append(respawn_text)
+
+        # Get squad kills
+        matches["Squad Kills"].append(squad_kills)
 
     def process_screenshot(self, image: Union[Path, np.ndarray, None] = None) -> None:
         summary_type = self.classify_summary_page(image)

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -294,7 +294,11 @@ class ApexOCREngine:
         return results_dict
 
     def process_squad_summary_page_helper(
-        self, img: Image, blur_amount: int, matches: DefaultDict, debug: bool = False
+        self,
+        img: Image.Image,
+        blur_amount: int,
+        matches: DefaultDict,
+        debug: bool = False,
     ):
         if img is None:
             logger.error(f"img is None")

--- a/apex_ocr/engine.py
+++ b/apex_ocr/engine.py
@@ -317,7 +317,7 @@ class ApexOCREngine:
         place_text = self.text_from_image_paddleocr(squad_place, blur_amount)
         total_kills_text = self.text_from_image_tesseract(
             total_kills, blur_amount, TESSERACT_BLOCK_CONFIG
-        )
+        ) # Want to replace tesseract here but PaddleOCR can't handle squad kills of 1 :(
 
         # Get squad placement
         matches["Place"].extend(

--- a/apex_ocr/roi.py
+++ b/apex_ocr/roi.py
@@ -207,7 +207,7 @@ def calculate_rois():
     )
 
 
-def get_rois(img: Image, debug: bool = False) -> Tuple[np.ndarray, np.ndarray, dict]:
+def get_rois(img: Image, debug: bool = False) -> Tuple[np.ndarray, dict]:
     if debug:
         from apex_ocr.config import DATA_DIRECTORY
         from datetime import datetime
@@ -216,14 +216,12 @@ def get_rois(img: Image, debug: bool = False) -> Tuple[np.ndarray, np.ndarray, d
         draw = ImageDraw.Draw(img)
         draw.rectangle([0, 0, 50, 50], width=3)
         draw.rectangle(SQUAD_PLACE_ROI, width=3)
-        draw.rectangle(TOTAL_KILLS_ROI, width=3)
         img.save(
             DATA_DIRECTORY
             / f"rois_img_{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}.png"
         )
 
     squad_place = np.array(img.crop(SQUAD_PLACE_ROI))
-    total_kill = np.array(img.crop(TOTAL_KILLS_ROI))
 
     players = {}
 
@@ -234,4 +232,4 @@ def get_rois(img: Image, debug: bool = False) -> Tuple[np.ndarray, np.ndarray, d
             player_images[stat[0]] = np.array(img.crop(img_region))
         players[player[0]] = player_images
 
-    return squad_place, total_kill, players
+    return squad_place, players

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,6 @@ Pygments==2.15.1
 PyMuPDF==1.20.2
 pyparsing==3.0.9
 pyrsistent==0.19.3
-pytesseract==0.3.10
 python-dateutil==2.8.2
 python-docx==0.8.11
 python-multipart==0.0.6


### PR DESCRIPTION
Removed all dependency on Pytesseract and replaced with calls to PaddleOCR. Because PaddleOCR couldn't reliably detect the number of squad kills in the upper-right region of the screenshot, that ROI is ignored and squad kills are now computed by summing the individual player kills. This may somewhat limit our ability to validate the OCR results because we won't be able to compare the two values (total squad kills at top of screen and sum of individual player kills), but not that big of an issue since we would likely throw out the results anyway if any of the individual kill results was misinterpreted.

Closes #22 